### PR TITLE
Make CONFIGATOR_MAX_LINES overrideable.

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@ NAME = sample
 CC = gcc
 FLAGS = -std=c99 -pedantic -g
 FLAGS+= -Wall -Wno-unused-parameter -Wextra -Werror=vla -Werror
+FLAGS+= $(EXTRAFLAGS)
 VALGRIND = --show-leak-kinds=all --track-origins=yes --leak-check=full
 
 BIND = bin

--- a/src/configator.h
+++ b/src/configator.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 
+#ifndef CONFIGATOR_MAX_LINE
 #define CONFIGATOR_MAX_LINE 80
+#endif
 
 #if 0
 #define CONFIGATOR_DEBUG


### PR DESCRIPTION
Wrap the CONFIGATOR_MAX_LINES preprocessor macro definition
with #ifndef. Add an EXTRAFLAGS makefile variable. Now, `make
EXTRAFLAGS=-DCONFIGATOR_MAX_LINE=999` can override the default
line limit.

This closes #2.